### PR TITLE
Adds support for chronicle_feed_microsoft_graph_api resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ website/vendor
 !command/test-fixtures/**/.terraform/
 
 dist/
+terraform-provider-chronicle

--- a/chronicle/provider.go
+++ b/chronicle/provider.go
@@ -197,6 +197,7 @@ func Provider() *schema.Provider {
 			"chronicle_feed_amazon_s3":                                NewResourceFeedAmazonS3().TerraformResource,
 			"chronicle_feed_amazon_sqs":                               NewResourceFeedAmazonSQS().TerraformResource,
 			"chronicle_feed_qualys_vm":                                NewResourceFeedQualysVM().TerraformResource,
+			"chronicle_feed_microsoft_graph_api":                      NewResourceFeedMicrosoftGraphAPI().TerraformResource,
 			"chronicle_feed_microsoft_office_365_management_activity": NewResourceFeedMicrosoftOffice365ManagementActivity().TerraformResource,
 			"chronicle_feed_okta_system_log":                          NewResourceFeedOktaSystemLog().TerraformResource,
 			"chronicle_feed_okta_users":                               NewResourceFeedOktaUsers().TerraformResource,

--- a/chronicle/resource_feed_microsoft_graph_api.go
+++ b/chronicle/resource_feed_microsoft_graph_api.go
@@ -1,0 +1,143 @@
+package chronicle
+
+import (
+	chronicle "github.com/form3tech-oss/terraform-provider-chronicle/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const (
+	FeedMicrosoftGraphAPIContentTypeAzureADAudit   = "AZURE_AD_AUDIT"
+	FeedMicrosoftGraphAPIContentTypeAzureADContext = "AZURE_AD_CONTEXT"
+	FeedMicrosoftGraphAPIContentTypeAzureSignIns   = "AZURE_AD"
+	FeedMicrosoftGraphAPIContentTypeAzureMDMIntune = "AZURE_MDM_INTUNE"
+	FeedMicrosoftGraphAPIContentTypeMSGraphAlert   = "MICROSOFT_GRAPH_ALERT"
+)
+
+type ResourceFeedMicrosoftGraphAPI struct {
+	TerraformResource *schema.Resource
+}
+
+func NewResourceFeedMicrosoftGraphAPI() *ResourceFeedMicrosoftGraphAPI {
+	details := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"hostname": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `API Full Path, default value: e.g. graph.microsoft.com/beta/security/alerts_v2`,
+			},
+			"tenant_id": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateUUID,
+				Description:      `Tenant ID (a UUID).`,
+			},
+			"retrieve_devices": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to retrieve devices from the directory when using AZURE_AD_CONTEXT.`,
+			},
+			"retrieve_groups": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to retrieve groups from the directory when using AZURE_AD_CONTEXT.`,
+			},
+			"auth_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Authentication endpoint to use when using MICROSOFT_GRAPH_ALERT.`,
+			},
+			"authentication": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: `Microsoft Graph API authentication details.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"client_id": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateUUID,
+							Description:      `OAuth client ID (a UUID).`,
+						},
+						"client_secret": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Sensitive:   true,
+							Description: `OAuth client secret.`,
+						},
+					},
+				},
+			},
+		},
+	}
+	description := "Creates a feed from API source type for a Microsoft Graph API log type."
+	microsoftGraphAPI := &ResourceFeedMicrosoftGraphAPI{}
+	microsoftGraphAPI.TerraformResource = newFeedResourceSchema(details, microsoftGraphAPI, description, true)
+
+	return microsoftGraphAPI
+}
+
+func (f *ResourceFeedMicrosoftGraphAPI) getLogType() string {
+	return ""
+}
+
+func (f *ResourceFeedMicrosoftGraphAPI) expandConcreteFeedConfiguration(d *schema.ResourceData) chronicle.ConcreteFeedConfiguration {
+
+	resourceDetailsInterface := readSliceFromResource(d, "details")
+	if resourceDetailsInterface == nil {
+		return nil
+	}
+
+	contentType := readStringFromResource(d, "log_type")
+
+	resourceDetails := resourceDetailsInterface[0].(map[string]interface{})
+	authenticationDetails := resourceDetails["authentication"].([]interface{})[0].(map[string]interface{})
+
+	return &chronicle.MicrosoftGraphAPIFeedConfiguration{
+		Hostname:        resourceDetails["hostname"].(string),
+		TenantID:        resourceDetails["tenant_id"].(string),
+		RetrieveDevices: resourceDetails["retrieve_devices"].(bool),
+		RetrieveGroups:  resourceDetails["retrieve_groups"].(bool),
+		AuthEndpoint:    resourceDetails["auth_endpoint"].(string),
+		ContentType:     contentType,
+		Authentication: chronicle.MicrosoftGraphAPIFeedAuthentication{
+			ClientID:     authenticationDetails["client_id"].(string),
+			ClientSecret: authenticationDetails["client_secret"].(string),
+		},
+	}
+}
+
+//nolint:all
+func (f *ResourceFeedMicrosoftGraphAPI) flattenDetailsFromReadOperation(originalConf chronicle.ConcreteFeedConfiguration, readConf chronicle.ConcreteFeedConfiguration) []map[string]interface{} {
+	readMicrosoftGraphAPIConf := readConf.(*chronicle.MicrosoftGraphAPIFeedConfiguration)
+	// Import Case
+	if originalConf == nil {
+		return []map[string]interface{}{{
+			"hostname":         readMicrosoftGraphAPIConf.Hostname,
+			"tenant_id":        readMicrosoftGraphAPIConf.TenantID,
+			"retrieve_devices": readMicrosoftGraphAPIConf.RetrieveDevices,
+			"retrieve_groups":  readMicrosoftGraphAPIConf.RetrieveGroups,
+			"auth_endpoint":    readMicrosoftGraphAPIConf.AuthEndpoint,
+			"authentication": []map[string]interface{}{{
+				"client_id":     readMicrosoftGraphAPIConf.Authentication.ClientID,
+				"client_secret": readMicrosoftGraphAPIConf.Authentication.ClientSecret,
+			}},
+		}}
+	}
+
+	originalMicrosoftGraphAPI := originalConf.(*chronicle.MicrosoftGraphAPIFeedConfiguration)
+	// Default Case
+	return []map[string]interface{}{{
+		// reponse strips out API endpoints. Workaround: get it from original
+		"hostname":         originalMicrosoftGraphAPI.Hostname,
+		"tenant_id":        readMicrosoftGraphAPIConf.TenantID,
+		"retrieve_devices": readMicrosoftGraphAPIConf.RetrieveDevices,
+		"retrieve_groups":  readMicrosoftGraphAPIConf.RetrieveGroups,
+		"auth_endpoint":    readMicrosoftGraphAPIConf.AuthEndpoint,
+		// replace authentication block with original values because they are not returned within a read request
+		"authentication": []map[string]interface{}{{
+			"client_id":     originalMicrosoftGraphAPI.Authentication.ClientID,
+			"client_secret": originalMicrosoftGraphAPI.Authentication.ClientSecret,
+		}},
+	}}
+}

--- a/chronicle/resource_feed_microsoft_graph_api_test.go
+++ b/chronicle/resource_feed_microsoft_graph_api_test.go
@@ -1,0 +1,232 @@
+package chronicle
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccChronicleFeedMicrosoftGraphAPI_Basic(t *testing.T) {
+	displayName := "testtf" + randString(10)
+	enabled := "true"
+	namespace := "test"
+	labels := `"test"="test"`
+	hostname := "graph.microsoft.com/v1.0/auditLogs/directoryAudits"
+	tenantID := "50352502-a347-11ed-a8fc-0242ac120001"
+	logType := "AZURE_AD_AUDIT"
+	clientID := "50352701-a307-11ed-a8fc-0242ac120001"
+	clientSecret := "000"
+
+	rootRef := feedMicrosoftGraphAPIRef("test")
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckChronicleFeedMicrosoftGraphAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckChronicleFeedMicrosoftGraphAPI(displayName, enabled, namespace, labels, hostname, logType, tenantID, clientID, clientSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChronicleFeedMicrosoftGraphAPIExists(rootRef),
+					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
+					resource.TestCheckResourceAttr(rootRef, "namespace", namespace),
+					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
+					resource.TestCheckResourceAttr(rootRef, "details.0.hostname", hostname),
+					resource.TestCheckResourceAttr(rootRef, "details.0.tenant_id", tenantID),
+				),
+			},
+			{
+				ResourceName:      rootRef,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"display_name", "state", "details.0.hostname", "details.0.authentication.0.client_id",
+					"details.0.authentication.0.client_secret"},
+			},
+		},
+	})
+}
+
+func TestAccChronicleFeedMicrosoftGraphAPI_UpdateAuth(t *testing.T) {
+	displayName := "testtf" + randString(10)
+	enabled := "true"
+	namespace := "test"
+	labels := `"test"="test"`
+	hostname := "graph.microsoft.com/v1.0/auditLogs/signIns"
+	tenantID := "50352702-a347-11ed-a8fc-0242ac120001"
+	logType := "AZURE_AD"
+	clientID := "50352701-a307-11ed-a8fc-0242ac120001"
+	clientID1 := "50352702-a307-11ed-a8fc-0242ac120001"
+	clientSecret := "000"
+	clientSecret1 := "001"
+
+	rootRef := feedMicrosoftGraphAPIRef("test")
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckChronicleFeedMicrosoftGraphAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckChronicleFeedMicrosoftGraphAPI(displayName, enabled, namespace, labels, logType, hostname, tenantID, clientID, clientSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChronicleFeedMicrosoftGraphAPIExists(rootRef),
+					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
+					resource.TestCheckResourceAttr(rootRef, "namespace", namespace),
+					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
+					resource.TestCheckResourceAttr(rootRef, "details.0.hostname", hostname),
+					resource.TestCheckResourceAttr(rootRef, "details.0.tenant_id", tenantID),
+				),
+			},
+			{
+				Config: testAccCheckChronicleFeedMicrosoftGraphAPI(displayName, enabled, namespace, labels, logType, hostname, tenantID, clientID1, clientSecret1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChronicleFeedMicrosoftGraphAPIExists(rootRef),
+					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
+					resource.TestCheckResourceAttr(rootRef, "namespace", namespace),
+					resource.TestCheckResourceAttr(rootRef, "details.0.hostname", hostname),
+					resource.TestCheckResourceAttr(rootRef, "details.0.tenant_id", tenantID),
+					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
+					testAccCheckChronicleFeedMicrosoftGraphAPIAuthUpdated(t, rootRef, clientID1, clientSecret1),
+				),
+			},
+			{
+				ResourceName:      rootRef,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"display_name", "state", "details.0.hostname", "details.0.authentication.0.client_id",
+					"details.0.authentication.0.client_secret"},
+			},
+		},
+	})
+}
+
+func TestAccChronicleFeedMicrosoftGraphAPI_UpdateEnabled(t *testing.T) {
+	displayName := "testtf" + randString(10)
+	enabled := "true"
+	notEnabled := "false"
+	namespace := "test"
+	labels := `"test"="test"`
+	hostname := "graph.microsoft.com/beta"
+	tenantID := "50352702-a347-11ed-a8fc-0242ac120001"
+	logType := "AZURE_AD_CONTEXT"
+	clientID := "50352701-a307-11ed-a8fc-0242ac120001"
+	clientSecret := "000"
+
+	rootRef := feedMicrosoftGraphAPIRef("test")
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckChronicleFeedMicrosoftGraphAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckChronicleFeedMicrosoftGraphAPI(displayName, enabled, namespace, labels, logType, hostname, tenantID, clientID, clientSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChronicleFeedMicrosoftGraphAPIExists(rootRef),
+					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
+					resource.TestCheckResourceAttr(rootRef, "namespace", namespace),
+					resource.TestCheckResourceAttr(rootRef, "details.0.hostname", hostname),
+					resource.TestCheckResourceAttr(rootRef, "details.0.tenant_id", tenantID),
+					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
+				),
+			},
+			{
+				Config: testAccCheckChronicleFeedMicrosoftGraphAPI(displayName, notEnabled, namespace, labels, logType, hostname, tenantID, clientID, clientSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChronicleFeedMicrosoftGraphAPIExists(rootRef),
+					resource.TestCheckResourceAttr(rootRef, "enabled", notEnabled),
+					resource.TestCheckResourceAttr(rootRef, "namespace", namespace),
+					resource.TestCheckResourceAttr(rootRef, "details.0.hostname", hostname),
+					resource.TestCheckResourceAttr(rootRef, "details.0.tenant_id", tenantID),
+					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
+				),
+			},
+			{
+				ResourceName:      rootRef,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"display_name", "state", "details.0.hostname", "details.0.authentication.0.client_id",
+					"details.0.authentication.0.client_secret"},
+			},
+		},
+	})
+}
+
+//nolint:unparam
+func testAccCheckChronicleFeedMicrosoftGraphAPIAuthUpdated(t *testing.T, n, clientID, clientSecret string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if rs.Primary.Attributes["details.0.authentication.0.client_id"] != clientID ||
+			rs.Primary.Attributes["details.0.authentication.0.client_secret"] != clientSecret {
+			return fmt.Errorf("clientID or clientSecret differs")
+		}
+
+		return nil
+	}
+}
+
+//nolint:unparam
+func testAccCheckChronicleFeedMicrosoftGraphAPI(displayName, enabled, namespace, labels, logType, hostname, tenantID, clientID, clientSecret string) string {
+	return fmt.Sprintf(
+		`resource "chronicle_feed_microsoft_graph_api" "test" {
+			display_name = "%s"
+			enabled = %s
+			namespace = "%s"
+			labels = {
+				%s
+			}
+			log_type = "%s"
+			details {
+				hostname = "%s"
+				tenant_id = "%s"
+				authentication {
+					client_id = "%s"
+					client_secret = "%s"
+				}
+			}
+			}`, displayName, enabled, namespace, labels, logType, hostname, tenantID, clientID, clientSecret)
+}
+
+func testAccCheckChronicleFeedMicrosoftGraphAPIExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return NewNotFoundErrorf("%s in state", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return NewNotFoundErrorf("ID for %s in state", n)
+		}
+		return nil
+	}
+}
+
+func testAccCheckChronicleFeedMicrosoftGraphAPIDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "chronicle_feed_microsoft_graph_api.test" {
+			continue
+		}
+
+		if rs.Primary.ID != "" {
+			return fmt.Errorf("Object %q still exists", rs.Primary.ID)
+		}
+		return nil
+	}
+	return nil
+}
+
+func feedMicrosoftGraphAPIRef(name string) string {
+	return fmt.Sprintf("chronicle_feed_microsoft_graph_api.%v", name)
+}

--- a/chronicle/validation.go
+++ b/chronicle/validation.go
@@ -186,7 +186,20 @@ func validateFeedMicrosoftOffice365ManagementActivityContentType(v interface{}, 
 		FeedMicrosoftOffice365ManagementActivityContentTypeDPLAll}
 	contentType := v.(string)
 	if !contains(contentTypes, contentType) {
-		return diag.FromErr(fmt.Errorf("conten type %s not valid, valid types are: %s", contentType, contentTypes))
+		return diag.FromErr(fmt.Errorf("content type %s not valid, valid types are: %s", contentType, contentTypes))
+	}
+	return nil
+}
+
+func validateFeedMicrosoftGraphAPIContentType(v interface{}, k cty.Path) diag.Diagnostics {
+	contentTypes := []string{FeedMicrosoftGraphAPIContentTypeAzureADAudit,
+		FeedMicrosoftGraphAPIContentTypeAzureADContext,
+		FeedMicrosoftGraphAPIContentTypeAzureMDMIntune,
+		FeedMicrosoftGraphAPIContentTypeAzureSignIns,
+		FeedMicrosoftGraphAPIContentTypeMSGraphAlert}
+	contentType := v.(string)
+	if !contains(contentTypes, contentType) {
+		return diag.FromErr(fmt.Errorf("content type %s not valid, valid types are: %s", contentType, contentTypes))
 	}
 	return nil
 }
@@ -197,7 +210,7 @@ func validateReferenceListContentType(v interface{}, k cty.Path) diag.Diagnostic
 		string(chronicle.ReferenceListContentTypeDefault)}
 	contentType := v.(string)
 	if !contains(contentTypes, contentType) {
-		return diag.FromErr(fmt.Errorf("conten type %s not valid, valid types are: %s", contentType, contentTypes))
+		return diag.FromErr(fmt.Errorf("content type %s not valid, valid types are: %s", contentType, contentTypes))
 	}
 	return nil
 }

--- a/client/feed.go
+++ b/client/feed.go
@@ -273,6 +273,10 @@ func newConcreteFeedConfiguration(feedSourceType, logType string) ConcreteFeedCo
 
 func newAPIConcreteFeedConfigurationFromLogType(logType string) ConcreteFeedConfiguration {
 	switch logType {
+
+	case "AZURE_AD_AUDIT", "AZURE_AD_CONTEXT", "AZURE_AD", "AZURE_MDM_INTUNE", "MICROSOFT_GRAPH_ALERT":
+		return &MicrosoftGraphAPIFeedConfiguration{ContentType: logType}
+
 	case MicrosoftOffice365ManagementActivityFeedLogType:
 		return &MicrosoftOffice365ManagementActivityFeedConfiguration{}
 

--- a/client/feed_microsoft_graph_api.go
+++ b/client/feed_microsoft_graph_api.go
@@ -1,0 +1,39 @@
+package client
+
+type MicrosoftGraphAPIFeedConfiguration struct {
+	TenantID       string                              `json:"tenantId,omitempty"`
+	ContentType    string                              `json:"-"`
+	Hostname       string                              `json:"hostname,omitempty"`
+	Authentication MicrosoftGraphAPIFeedAuthentication `json:"authentication,omitempty"`
+
+	// Only for AZURE_AD_CONTEXT
+	RetrieveDevices bool `json:"retrieveDevices,omitempty"`
+	RetrieveGroups  bool `json:"retrieveGroups,omitempty"`
+
+	// Only for MICROSOFT_GRAPH_ALERT
+	AuthEndpoint string `json:"authEndpoint,omitempty"`
+}
+type MicrosoftGraphAPIFeedAuthentication struct {
+	ClientID     string `json:"clientId,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty"`
+}
+
+func (config *MicrosoftGraphAPIFeedConfiguration) getConfigurationPropertyKey() string {
+	switch key := config.ContentType; key {
+	case "AZURE_AD_AUDIT":
+		return "azureAdAuditSettings"
+	case "AZURE_AD_CONTEXT":
+		return "azureAdContextSettings"
+	case "AZURE_AD":
+		return "azureAdSettings"
+	case "AZURE_MDM_INTUNE":
+		return "azureMdmIntuneSettings"
+	case "MICROSOFT_GRAPH_ALERT":
+		return "microsoftGraphAlertSettings"
+	default:
+		return ""
+	}
+}
+func (config *MicrosoftGraphAPIFeedConfiguration) getFeedSourceType() string {
+	return FeedSourceTypeAPI
+}

--- a/client/transport.go
+++ b/client/transport.go
@@ -52,9 +52,6 @@ func sendRequest(client *Client, httpClient *http.Client, method, userAgent stri
 				return errorForStatusCode(res, err)
 			}
 
-			if err != nil {
-				return err
-			}
 			return nil
 		}, retry.Attempts(client.requestAttempts), retry.DelayType(retry.BackOffDelay), retry.OnRetry(func(n uint, err error) {
 			log.Printf("[DEBUG] Retrying request after error: %v", err)

--- a/examples/resources/feed/api/microsoft_graph_api/main.tf
+++ b/examples/resources/feed/api/microsoft_graph_api/main.tf
@@ -1,0 +1,120 @@
+// Defaults to provider subscription id
+data "azurerm_subscription" "current" {
+}
+// Use current principal to own azuread_application resource
+data "azurerm_client_config" "current" {}
+
+locals {
+  resource_tags = {
+    "managed-by" = "terraform"
+  }
+  event_namespace = "my-namespace"
+}
+
+// Create Application servicePrincipal with rights to Graph API
+resource "azuread_application" "chronicle_graphapi" {
+  display_name = "chronicle-graphapi-ingest"
+  owners       = [data.azuread_client_config.current.object_id]
+  required_resource_access {
+    # Retrieved with:
+    # az ad sp list --display-name "Microsoft Graph" --query '[].{appDisplayName:appDisplayName, appId:appId}'
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+    # Retrieved with:
+    # az ad sp show --id 00000003-0000-0000-c000-000000000000 | \
+    #   jq '.appRoles[] | select (.value == "SecurityActions.Read.All" or .value == "SecurityEvens.Read.All")'
+    resource_access {
+      id   = "5e0edab9-c148-49d0-b423-ac253e121825" # SecurityActions.Read.All
+      type = "Role"
+    }
+    resource_access {
+      id   = "bf394140-e372-4bf9-a898-299cfc7564e5" # SecurityEvents.Read.All
+      type = "Role"
+    }
+    resource_access {
+      id   = "b0afded3-3588-46d8-8b3d-9842eff778da" # AuditLog.Read.All
+      type = "Role"
+    }
+    resource_access {
+      id   = "7ab1d382-f21e-4acd-a863-ba3e13f7da61" # Directory.Read.All
+      type = "Role"
+    }
+  }
+  tags = [for k, v in local.resource_tags : "${k}:${v}"]
+}
+
+// Create an application password
+resource "azuread_application_password" "graphapi_pw" {
+  display_name   = "Chronicle GraphAPI Feeds"
+  application_id = azuread_application.chronicle_graphapi.id
+}
+
+// Graph Alerts
+resource "chronicle_feed_microsoft_graph_api" "alerts" {
+  enabled      = true
+  display_name = "MS Graph - Alerts"
+  namespace    = local.event_namespace
+  log_type     = "MICROSOFT_GRAPH_ALERT"
+  details {
+    tenant_id     = data.azurerm_subscription.current.tenant_id
+    hostname      = "graph.microsoft.com/v1.0/security/alerts"
+    auth_endpoint = "login.microsoftonline.com"
+    authentication {
+      client_id     = azuread_application.chronicle_graphapi.client_id
+      client_secret = azuread_application_password.graphapi_pw.value
+    }
+  }
+  labels = merge(local.resource_tags, { "ingest-path" = "api"})
+}
+
+// Capture directoryAudit events
+resource "chronicle_feed_microsoft_graph_api" "azure_ad_audit" {
+  enabled      = true
+  display_name = "MS Graph - directoryAudit"
+  namespace    = local.event_namespace
+  log_type     = "AZURE_AD_AUDIT"
+  details {
+    tenant_id = data.azurerm_subscription.current.tenant_id
+    hostname  = "graph.microsoft.com/v1.0/auditLogs/directoryAudits"
+    authentication {
+      client_id     = azuread_application.chronicle_graphapi.client_id
+      client_secret = azuread_application_password.graphapi_pw.value
+    }
+  }
+  labels = merge(local.resource_tags, { "ingest-path" = "api" })
+}
+
+// Sign-In events
+resource "chronicle_feed_microsoft_graph_api" "azure_ad" {
+  enabled      = true
+  display_name = "MS Graph - signIns"
+  namespace    = local.event_namespace
+  log_type     = "AZURE_AD"
+  details {
+    tenant_id = data.azurerm_subscription.current.tenant_id
+    hostname  = "graph.microsoft.com/v1.0/auditLogs/signIns"
+    authentication {
+      client_id     = azuread_application.chronicle_graphapi.client_id
+      client_secret = azuread_application_password.graphapi_pw.value
+    }
+  }
+  labels = merge(local.resource_tags, { "ingest-path" = "api" })
+}
+
+// Use Azure AD for context enrichment
+resource "chronicle_feed_microsoft_graph_api" "azure_ad_context" {
+  enabled      = true
+  display_name = "MS Graph - AD Context"
+  namespace    = local.event_namespace
+  log_type     = "AZURE_AD_CONTEXT"
+  details {
+    tenant_id        = data.azurerm_subscription.current.tenant_id
+    hostname         = "graph.microsoft.com/beta"
+    retrieve_devices = true
+    retrieve_groups  = true
+    authentication {
+      client_id     = azuread_application.chronicle_graphapi.client_id
+      client_secret = azuread_application_password.graphapi_pw.value
+    }
+  }
+  labels = merge(local.resource_tags, { "ingest-path" = "api" })
+}

--- a/templates/resources/feed_microsoft_graph_api.tmpl
+++ b/templates/resources/feed_microsoft_graph_api.tmpl
@@ -1,0 +1,16 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{ tffile "examples/resources/feed/api/microsoft_graph_api/main.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
I feel this might be somewhat hacky, as I haven't written any terraform plugins before and not an expert in golang, _but_ this adds support for the various MS Graph API resource types.

The biggest hacky part is that the schema options of `retrieve_devices`, `retrieve_groups`, and `auth_endpoint` don't apply to all feeds and this isn't currently validated.

But thanks for all your work!