### PR TITLE
chore: change update tests & improve release process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,13 @@
 name: CI
 on:
-  push:
   pull_request:
+    types:
+      - synchronize
+      - opened
+      - reopened
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,13 @@
 name: golangci-lint
 on:
-  push:
   pull_request:
+    types:
+      - synchronize
+      - opened
+      - reopened
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,27 +1,26 @@
 name: release
 on:
   push:
-    branches:
-      - master
     tags:
-      - v*.*.*
+      - "v*.*.*"
 
 permissions:
   contents: write
 
 jobs:
   publish:
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+
       - name: Setup Golang
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: go.mod
+          
       - name: Go releaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:

--- a/chronicle/provider_test.go
+++ b/chronicle/provider_test.go
@@ -1,11 +1,11 @@
 package chronicle
 
 import (
-	"math/rand"
 	"strings"
 	"testing"
 
 	chronicle "github.com/form3tech-oss/terraform-provider-chronicle/client"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,11 +37,11 @@ func testAccPreCheck(t *testing.T) {
 }
 
 func randString(length int) string {
-	result := make([]byte, length)
-	set := "abcdefghijklmnopqrstuvwxyz012346789"
-	for i := 0; i < length; i++ {
-		//nolint:all
-		result[i] = set[rand.Intn(len(set))]
+	id := uuid.New().String()
+
+	if len(id) > length {
+		id = id[:length]
 	}
-	return string(result)
+
+	return id
 }

--- a/chronicle/resource_feed_amazon_s3_test.go
+++ b/chronicle/resource_feed_amazon_s3_test.go
@@ -49,6 +49,7 @@ func TestAccChronicleFeedAmazonS3_Basic(t *testing.T) {
 
 func TestAccChronicleFeedAmazonS3_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	enabled := "true"
 	namespace := "test"
@@ -79,7 +80,7 @@ func TestAccChronicleFeedAmazonS3_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonS3(displayName, logType, enabled, namespace, labels, s3Uri, s3SourceType, sourceDeleteOptions, region1, accesKeyID1, secretAccessKey1),
+				Config: testAccCheckChronicleFeedAmazonS3(displayName1, logType, enabled, namespace, labels, s3Uri, s3SourceType, sourceDeleteOptions, region1, accesKeyID1, secretAccessKey1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonS3Exists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
@@ -101,6 +102,7 @@ func TestAccChronicleFeedAmazonS3_UpdateAuth(t *testing.T) {
 
 func TestAccChronicleFeedAmazonS3_UpdateEnabled(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	enabled := "true"
 	notEnabled := "false"
@@ -129,7 +131,7 @@ func TestAccChronicleFeedAmazonS3_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonS3(displayName, logType, notEnabled, namespace, labels, s3Uri, s3SourceType, sourceDeleteOptions, region, accesKeyID, secretAccessKey),
+				Config: testAccCheckChronicleFeedAmazonS3(displayName1, logType, notEnabled, namespace, labels, s3Uri, s3SourceType, sourceDeleteOptions, region, accesKeyID, secretAccessKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonS3Exists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
@@ -150,6 +152,7 @@ func TestAccChronicleFeedAmazonS3_UpdateEnabled(t *testing.T) {
 
 func TestAccChronicleFeedAmazonS3_UpdateLogType(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	logType1 := "AWS_CLOUDTRAIL"
 	notEnabled := "false"
@@ -178,7 +181,7 @@ func TestAccChronicleFeedAmazonS3_UpdateLogType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonS3(displayName, logType1, notEnabled, namespace, labels, s3Uri, s3SourceType, sourceDeleteOptions, region, accesKeyID, secretAccessKey),
+				Config: testAccCheckChronicleFeedAmazonS3(displayName1, logType1, notEnabled, namespace, labels, s3Uri, s3SourceType, sourceDeleteOptions, region, accesKeyID, secretAccessKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonS3Exists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType1),

--- a/chronicle/resource_feed_amazon_sqs_test.go
+++ b/chronicle/resource_feed_amazon_sqs_test.go
@@ -104,6 +104,7 @@ func TestAccChronicleFeedAmazonSQS_BasicWithS3Auth(t *testing.T) {
 
 func TestAccChronicleFeedAmazonSQS_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	enabled := "true"
 	namespace := "test"
@@ -139,7 +140,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName, logType, enabled, namespace, labels, queue, region1, accountNumber,
+				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName1, logType, enabled, namespace, labels, queue, region1, accountNumber,
 					sourceDeleteOptions, sqsAccesKeyID1, sqsSecretAccessKey1, s3AccesKeyID1, s3SecretAccessKey1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonSQSExists(rootRef),
@@ -162,6 +163,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateAuth(t *testing.T) {
 
 func TestAccChronicleFeedAmazonSQS_UpdateEnabled(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	enabled := "true"
 	notEnabled := "false"
@@ -193,7 +195,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName, logType, notEnabled, namespace, labels, queue, region, accountNumber,
+				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName1, logType, notEnabled, namespace, labels, queue, region, accountNumber,
 					sourceDeleteOptions, sqsAccesKeyID, sqsSecretAccessKey, s3AccesKeyID, s3SecretAccessKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonSQSExists(rootRef),
@@ -215,6 +217,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateEnabled(t *testing.T) {
 
 func TestAccChronicleFeedAmazonSQS_UpdateLogType(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	logType1 := "AWS_CLOUDTRAIL"
 	notEnabled := "false"
@@ -246,7 +249,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateLogType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName, logType1, notEnabled, namespace, labels, queue, region, accountNumber,
+				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName1, logType1, notEnabled, namespace, labels, queue, region, accountNumber,
 					sourceDeleteOptions, sqsAccesKeyID, sqsSecretAccessKey, s3AccesKeyID, s3SecretAccessKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonSQSExists(rootRef),
@@ -268,6 +271,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateLogType(t *testing.T) {
 
 func TestAccChronicleFeedAmazonSQS_UpdateAccountNumber(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	notEnabled := "false"
 	namespace := "test"
@@ -300,7 +304,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateAccountNumber(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName, logType, notEnabled, namespace, labels, queue, region, accountNumber1,
+				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName1, logType, notEnabled, namespace, labels, queue, region, accountNumber1,
 					sourceDeleteOptions, sqsAccesKeyID, sqsSecretAccessKey, s3AccesKeyID, s3SecretAccessKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonSQSExists(rootRef),
@@ -323,6 +327,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateAccountNumber(t *testing.T) {
 
 func TestAccChronicleFeedAmazonSQS_UpdateRegion(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	notEnabled := "false"
 	namespace := "test"
@@ -355,7 +360,7 @@ func TestAccChronicleFeedAmazonSQS_UpdateRegion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName, logType, notEnabled, namespace, labels, queue, region1, accountNumber,
+				Config: testAccCheckChronicleFeedAmazonSQSWithS3Auth(displayName1, logType, notEnabled, namespace, labels, queue, region1, accountNumber,
 					sourceDeleteOptions, sqsAccesKeyID, sqsSecretAccessKey, s3AccesKeyID, s3SecretAccessKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAmazonSQSExists(rootRef),

--- a/chronicle/resource_feed_azure_blobstore_test.go
+++ b/chronicle/resource_feed_azure_blobstore_test.go
@@ -47,6 +47,7 @@ func TestAccChronicleFeedAzureBlobStore_Basic(t *testing.T) {
 
 func TestAccChronicleFeedAzureBlobStore_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	enabled := "true"
 	namespace := "test"
@@ -73,7 +74,7 @@ func TestAccChronicleFeedAzureBlobStore_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAzureBlobStore(displayName, logType, enabled, namespace, labels, uri, sourceType, sharedKey1),
+				Config: testAccCheckChronicleFeedAzureBlobStore(displayName1, logType, enabled, namespace, labels, uri, sourceType, sharedKey1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAzureBlobStoreExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
@@ -97,6 +98,7 @@ func TestAccChronicleFeedAzureBlobStore_UpdateEnabled(t *testing.T) {
 	enabled := "true"
 	notEnabled := "false"
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "GITHUB"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -121,7 +123,7 @@ func TestAccChronicleFeedAzureBlobStore_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAzureBlobStore(displayName, logType, notEnabled, namespace, labels, uri, sourceType, sharedKey),
+				Config: testAccCheckChronicleFeedAzureBlobStore(displayName1, logType, notEnabled, namespace, labels, uri, sourceType, sharedKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAzureBlobStoreExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
@@ -143,6 +145,7 @@ func TestAccChronicleFeedAzureBlobStore_UpdateEnabled(t *testing.T) {
 
 func TestAccChronicleFeedAzureBlobStore_UpdateLogType(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	notEnabled := "false"
 	logType := "GITHUB"
 	logType1 := "AWS_CLOUDTRAIL"
@@ -168,7 +171,7 @@ func TestAccChronicleFeedAzureBlobStore_UpdateLogType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedAzureBlobStore(displayName, logType1, notEnabled, namespace, labels, uri, sourceType, sharedKey),
+				Config: testAccCheckChronicleFeedAzureBlobStore(displayName1, logType1, notEnabled, namespace, labels, uri, sourceType, sharedKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedAzureBlobStoreExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType1),

--- a/chronicle/resource_feed_google_cloud_storage_bucket_test.go
+++ b/chronicle/resource_feed_google_cloud_storage_bucket_test.go
@@ -48,6 +48,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_Basic(t *testing.T) {
 
 func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateBucketSourceType(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "ONEPASSWORD"
 	enabled := "true"
 	namespace := "test"
@@ -76,7 +77,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateBucketSourceType(t *test
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName, logType, enabled, namespace, labels, bucketUri, bucketSourceType1, sourceDeleteOptions),
+				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName1, logType, enabled, namespace, labels, bucketUri, bucketSourceType1, sourceDeleteOptions),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedGoogleCloudStorageBucketExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
@@ -99,6 +100,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateBucketSourceType(t *test
 
 func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateSourceDeletionOptions(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "ONEPASSWORD"
 	enabled := "true"
 	namespace := "test"
@@ -127,7 +129,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateSourceDeletionOptions(t 
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName, logType, enabled, namespace, labels, bucketUri, bucketSourceType, sourceDeleteOptions1),
+				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName1, logType, enabled, namespace, labels, bucketUri, bucketSourceType, sourceDeleteOptions1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedGoogleCloudStorageBucketExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType),
@@ -150,6 +152,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateSourceDeletionOptions(t 
 
 func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateLogType(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "ONEPASSWORD"
 	logType1 := "AWS_CLOUDTRAIL"
 	enabled := "true"
@@ -178,7 +181,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateLogType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName, logType1, enabled, namespace, labels, bucketUri, bucketSourceType, sourceDeleteOptions),
+				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName1, logType1, enabled, namespace, labels, bucketUri, bucketSourceType, sourceDeleteOptions),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedGoogleCloudStorageBucketExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType1),
@@ -201,6 +204,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateLogType(t *testing.T) {
 
 func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateNamespace(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(10)
 	logType := "ONEPASSWORD"
 	enabled := "true"
 	namespace := "test"
@@ -229,7 +233,7 @@ func TestAccChronicleFeedGoogleCloudStorageBucket_UpdateNamespace(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName, logType, enabled, namespace1, labels, bucketUri, bucketSourceType, sourceDeleteOptions),
+				Config: testAccCheckChronicleFeedGoogleCloudStorageBucket(displayName1, logType, enabled, namespace1, labels, bucketUri, bucketSourceType, sourceDeleteOptions),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedGoogleCloudStorageBucketExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "log_type", logType),

--- a/chronicle/resource_feed_microsoft_office_365_management_activity_test.go
+++ b/chronicle/resource_feed_microsoft_office_365_management_activity_test.go
@@ -50,6 +50,7 @@ func TestAccChronicleFeedMicrosoftOffice365ManagementActivity_Basic(t *testing.T
 
 func TestAccChronicleFeedMicrosoftOffice365ManagementActivity_UpdateAuth(t *testing.T) {
 	displayName := "testtf" + randString(10)
+	displayName1 := "testf" + randString(10)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -80,7 +81,7 @@ func TestAccChronicleFeedMicrosoftOffice365ManagementActivity_UpdateAuth(t *test
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedMicrosoftOffice365ManagementActivity(displayName, enabled, namespace, labels, hostname, tenantID, contentType, clientID1, clientSecret1),
+				Config: testAccCheckChronicleFeedMicrosoftOffice365ManagementActivity(displayName1, enabled, namespace, labels, hostname, tenantID, contentType, clientID1, clientSecret1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedMicrosoftOffice365ManagementActivityExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
@@ -104,6 +105,7 @@ func TestAccChronicleFeedMicrosoftOffice365ManagementActivity_UpdateAuth(t *test
 
 func TestAccChronicleFeedMicrosoftOffice365ManagementActivity_UpdateEnabled(t *testing.T) {
 	displayName := "testtf" + randString(10)
+	displayName1 := "testf" + randString(10)
 	enabled := "true"
 	notEnabled := "false"
 	namespace := "test"
@@ -133,7 +135,7 @@ func TestAccChronicleFeedMicrosoftOffice365ManagementActivity_UpdateEnabled(t *t
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedMicrosoftOffice365ManagementActivity(displayName, notEnabled, namespace, labels, hostname, tenantID, contentType, clientID, clientSecret),
+				Config: testAccCheckChronicleFeedMicrosoftOffice365ManagementActivity(displayName1, notEnabled, namespace, labels, hostname, tenantID, contentType, clientID, clientSecret),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedMicrosoftOffice365ManagementActivityExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", notEnabled),

--- a/chronicle/resource_feed_okta_system_log_test.go
+++ b/chronicle/resource_feed_okta_system_log_test.go
@@ -46,6 +46,7 @@ func TestAccChronicleFeedOktaSystemLog_Basic(t *testing.T) {
 
 func TestAccChronicleFeedOktaSystemLog_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -72,7 +73,7 @@ func TestAccChronicleFeedOktaSystemLog_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedOktaSystemLog(displayName, enabled, namespace, labels, hostname, key1, value1),
+				Config: testAccCheckChronicleFeedOktaSystemLog(displayName1, enabled, namespace, labels, hostname, key1, value1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedOktaSystemLogExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
@@ -93,6 +94,7 @@ func TestAccChronicleFeedOktaSystemLog_UpdateAuth(t *testing.T) {
 
 func TestAccChronicleFeedOktaSystemLog_UpdateEnabled(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	notEnabled := "false"
 	namespace := "test"
@@ -118,7 +120,7 @@ func TestAccChronicleFeedOktaSystemLog_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedOktaSystemLog(displayName, notEnabled, namespace, labels, hostname, key, value),
+				Config: testAccCheckChronicleFeedOktaSystemLog(displayName1, notEnabled, namespace, labels, hostname, key, value),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedOktaSystemLogExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", notEnabled),
@@ -139,6 +141,7 @@ func TestAccChronicleFeedOktaSystemLog_UpdateEnabled(t *testing.T) {
 
 func TestAccChronicleOktaSystemLog_UpdateHostname(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -164,7 +167,7 @@ func TestAccChronicleOktaSystemLog_UpdateHostname(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedOktaSystemLog(displayName, enabled, namespace, labels, hostname1, key, value),
+				Config: testAccCheckChronicleFeedOktaSystemLog(displayName1, enabled, namespace, labels, hostname1, key, value),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedOktaSystemLogExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),

--- a/chronicle/resource_feed_okta_users_test.go
+++ b/chronicle/resource_feed_okta_users_test.go
@@ -47,6 +47,7 @@ func TestAccChronicleFeedOktaUsers_Basic(t *testing.T) {
 
 func TestAccChronicleFeedOktaUsers_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -74,7 +75,7 @@ func TestAccChronicleFeedOktaUsers_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedOktaUsers(displayName, enabled, namespace, labels, hostname, manager_id, key1, value1),
+				Config: testAccCheckChronicleFeedOktaUsers(displayName1, enabled, namespace, labels, hostname, manager_id, key1, value1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedOktaUsersExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
@@ -95,6 +96,7 @@ func TestAccChronicleFeedOktaUsers_UpdateAuth(t *testing.T) {
 
 func TestAccChronicleFeedOktaUsers_UpdateEnabled(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	notEnabled := "false"
 	namespace := "test"
@@ -121,7 +123,7 @@ func TestAccChronicleFeedOktaUsers_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedOktaUsers(displayName, notEnabled, namespace, labels, hostname, manager_id, key, value),
+				Config: testAccCheckChronicleFeedOktaUsers(displayName1, notEnabled, namespace, labels, hostname, manager_id, key, value),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedOktaUsersExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", notEnabled),
@@ -142,6 +144,7 @@ func TestAccChronicleFeedOktaUsers_UpdateEnabled(t *testing.T) {
 
 func TestAccChronicleOktaUsers_UpdateHostname(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -168,7 +171,7 @@ func TestAccChronicleOktaUsers_UpdateHostname(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedOktaUsers(displayName, enabled, namespace, labels, hostname1, manager_id, key, value),
+				Config: testAccCheckChronicleFeedOktaUsers(displayName1, enabled, namespace, labels, hostname1, manager_id, key, value),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedOktaUsersExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),

--- a/chronicle/resource_feed_proofpoint_siem_test.go
+++ b/chronicle/resource_feed_proofpoint_siem_test.go
@@ -44,6 +44,7 @@ func TestAccChronicleProofpointSIEM_Basic(t *testing.T) {
 
 func TestAccChronicleProofpointSIEM_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -68,7 +69,7 @@ func TestAccChronicleProofpointSIEM_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleProofpointSIEM(displayName, enabled, namespace, labels, user1, secret1),
+				Config: testAccCheckChronicleProofpointSIEM(displayName1, enabled, namespace, labels, user1, secret1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleProofpointSIEMExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
@@ -89,6 +90,7 @@ func TestAccChronicleProofpointSIEM_UpdateAuth(t *testing.T) {
 
 func TestAccChronicleProofpointSIEM_UpdateEnabled(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	notEnabled := "true"
 	namespace := "test"
@@ -112,7 +114,7 @@ func TestAccChronicleProofpointSIEM_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleProofpointSIEM(displayName, notEnabled, namespace, labels, user, secret),
+				Config: testAccCheckChronicleProofpointSIEM(displayName1, notEnabled, namespace, labels, user, secret),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleProofpointSIEMExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),

--- a/chronicle/resource_feed_qualys_vm_test.go
+++ b/chronicle/resource_feed_qualys_vm_test.go
@@ -46,6 +46,7 @@ func TestAccChronicleFeedQualysVM_Basic(t *testing.T) {
 
 func TestAccChronicleFeedQualysVM_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -72,7 +73,7 @@ func TestAccChronicleFeedQualysVM_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedQualysVM(displayName, enabled, namespace, labels, hostname, user1, secret1),
+				Config: testAccCheckChronicleFeedQualysVM(displayName1, enabled, namespace, labels, hostname, user1, secret1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedQualysVMExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
@@ -94,6 +95,7 @@ func TestAccChronicleFeedQualysVM_UpdateAuth(t *testing.T) {
 
 func TestAccChronicleFeedQualysVM_UpdateEnabled(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	notEnabled := "false"
 	namespace := "test"
@@ -119,7 +121,7 @@ func TestAccChronicleFeedQualysVM_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedQualysVM(displayName, notEnabled, namespace, labels, hostname, user, secret),
+				Config: testAccCheckChronicleFeedQualysVM(displayName1, notEnabled, namespace, labels, hostname, user, secret),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedQualysVMExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", notEnabled),
@@ -140,6 +142,7 @@ func TestAccChronicleFeedQualysVM_UpdateEnabled(t *testing.T) {
 
 func TestAccChronicleFeedQualysVM_UpdateHostname(t *testing.T) {
 	displayName := "test" + randString(10)
+	displayName1 := "test" + randString(40)
 	notEnabled := "false"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -165,7 +168,7 @@ func TestAccChronicleFeedQualysVM_UpdateHostname(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedQualysVM(displayName, notEnabled, namespace, labels, hostname1, user, secret),
+				Config: testAccCheckChronicleFeedQualysVM(displayName1, notEnabled, namespace, labels, hostname1, user, secret),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedQualysVMExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", notEnabled),

--- a/chronicle/resource_feed_thinkst_canary_test.go
+++ b/chronicle/resource_feed_thinkst_canary_test.go
@@ -46,6 +46,7 @@ func TestAccChronicleFeedThinkstCanary_Basic(t *testing.T) {
 
 func TestAccChronicleFeedThinkstCanary_UpdateAuth(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -71,7 +72,7 @@ func TestAccChronicleFeedThinkstCanary_UpdateAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedThinkstCanary(displayName, enabled, namespace, labels, hostname, key, value1),
+				Config: testAccCheckChronicleFeedThinkstCanary(displayName1, enabled, namespace, labels, hostname, key, value1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedThinkstCanaryExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),
@@ -92,6 +93,7 @@ func TestAccChronicleFeedThinkstCanary_UpdateAuth(t *testing.T) {
 
 func TestAccChronicleFeedThinkstCanary_UpdateEnabled(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	notEnabled := "false"
 	namespace := "test"
@@ -117,7 +119,7 @@ func TestAccChronicleFeedThinkstCanary_UpdateEnabled(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedThinkstCanary(displayName, notEnabled, namespace, labels, hostname, key, value),
+				Config: testAccCheckChronicleFeedThinkstCanary(displayName1, notEnabled, namespace, labels, hostname, key, value),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedThinkstCanaryExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", notEnabled),
@@ -138,6 +140,7 @@ func TestAccChronicleFeedThinkstCanary_UpdateEnabled(t *testing.T) {
 
 func TestAccChronicleThinkstCanary_UpdateHostname(t *testing.T) {
 	displayName := "test" + randString(40)
+	displayName1 := "test" + randString(40)
 	enabled := "true"
 	namespace := "test"
 	labels := `"test"="test"`
@@ -163,7 +166,7 @@ func TestAccChronicleThinkstCanary_UpdateHostname(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckChronicleFeedThinkstCanary(displayName, enabled, namespace, labels, hostname1, key, value),
+				Config: testAccCheckChronicleFeedThinkstCanary(displayName1, enabled, namespace, labels, hostname1, key, value),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChronicleFeedThinkstCanaryExists(rootRef),
 					resource.TestCheckResourceAttr(rootRef, "enabled", enabled),

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -26,3 +26,5 @@ changelog:
     exclude:
       - "^Merge pull request"
       - "^Merge branch"
+release:
+  prerelease: auto


### PR DESCRIPTION
When running update tests on feeds, if the display name is not updated, chronicle returns an error due to a change on their side. This PR make sure display name is alway updated.

Other features:
- Changed random string generator to uuid
- Improve release process