### PR TITLE
chore: update `golangci-lint` config and fix unsafe `int` to `uint` conversion

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,5 @@
 run:
   concurrency: 1
-  skip-dirs:
-    - vendor
   timeout: 3m
   modules-download-mode: vendor
   allow-parallel-runners: false
@@ -13,7 +11,6 @@ linters:
     - staticcheck
     - typecheck
     - unused
-    - vet
     - stylecheck
     - gocyclo
     - gofmt
@@ -22,7 +19,6 @@ linters:
     - asciicheck
     - bodyclose
     - dogsled
-    - exportloopref
     - gocognit
     - gocritic
     - godot
@@ -44,7 +40,10 @@ linters:
 
 linters-settings:
   errcheck:
-    ignore: bytes:.*,io:Close|Write
+    exclude-functions:
+      - bytes.*
+      - io.Close
+      - io.Write
 
   lll:
     line-length: 180
@@ -54,6 +53,8 @@ linters-settings:
     camel_name: false
 
 issues:
+  exclude-dirs:
+    - vendor
   exclude-rules:
     - path: _test\.go
       linters:

--- a/chronicle/provider.go
+++ b/chronicle/provider.go
@@ -233,7 +233,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		opts = append(opts, chronicle.WithRequestTimeout(time.Duration(v.(int))*time.Second))
 	}
 	if v, ok := d.GetOk("request_attempts"); ok {
-		opts = append(opts, chronicle.WithRequestAttempts(uint(v.(int))))
+		attempts := v.(int)
+		if attempts < 0 {
+			return nil, diag.FromErr(fmt.Errorf("request_attempts must be non-negative"))
+		}
+		opts = append(opts, chronicle.WithRequestAttempts(uint(attempts)))
 	}
 
 	//nolint:all


### PR DESCRIPTION
## Summary

This PR updates the `.golangci.yaml` configuration to align with the latest `golangci-lint` standards (v1.64.8) and fixes a runtime-linting failure due to unsafe integer conversion flagged by `gosec`.

## Changes

### Linter Config Updates
- Replaced deprecated `run.skip-dirs` with `issues.exclude-dirs`
- Replaced `errcheck.ignore` with `errcheck.exclude-functions`
- Removed deprecated linters:
  - `vet` (replaced by `govet`)
  - `exportloopref` (deprecated since Go 1.22 support)
- Confirmed YAML is valid and compatible with GHA runner version and `golangci-lint` 1.64.8

### Code Fixes
- Added validation to `request_attempts` in `provider.go` to ensure the value is non-negative before converting from `int` to `uint`
- Prevents a potential integer overflow, satisfying `gosec` rule `G115`

## Impact

- Eliminates all deprecation warnings in GitHub Actions
- Prevents unsafe int → uint conversion that caused lint job failures
- Ensures forward compatibility with future `golangci-lint` releases
- No impact on functional behavior for users providing valid input
- Adds a clear diagnostic message for invalid (negative) `request_attempts` configuration
