### PR TITLE
fix: remove access_token credential options

### DIFF
--- a/chronicle/provider.go
+++ b/chronicle/provider.go
@@ -303,7 +303,7 @@ func getAPIAuthOpts(d *schema.ResourceData) []chronicle.Option {
 
 	if v, ok := d.GetOk("backstoryapi_credentials"); ok {
 		opts = append(opts, chronicle.WithBackstoryAPICredentials(v.(string)))
-	} else if v, ok := d.GetOk("backstoryapi_access_token"); ok {
+	} else if v, ok := d.GetOk("backstoryapi_credentials"); ok {
 		opts = append(opts, chronicle.WithBackstoryAPIAccessToken(v.(string)))
 	} else {
 		env := envSearch(chronicle.BackstoryAPIEnvVar)
@@ -314,7 +314,7 @@ func getAPIAuthOpts(d *schema.ResourceData) []chronicle.Option {
 
 	if v, ok := d.GetOk("ingestionapi_credentials"); ok {
 		opts = append(opts, chronicle.WithIngestionAPICredentials(v.(string)))
-	} else if v, ok := d.GetOk("ingestionapi_access_token"); ok {
+	} else if v, ok := d.GetOk("ingestionapi_credentials"); ok {
 		opts = append(opts, chronicle.WithIngestionAPIAccessToken(v.(string)))
 	} else {
 		env := envSearch(chronicle.IngestionAPIEnvVar)


### PR DESCRIPTION
Reverts the addition of `backstoryapi_access_token` and `ingestionapi_access_token` options introduced in v0.0.5.

These additions were unnecessary as:
- The existing `backstoryapi_credentials` and `ingestionapi_credentials` options already support both credential files and access tokens
- Adding separate access_token options creates confusion about which option to use
- No corresponding documentation was added explaining when to use one vs the other

The V2 feed support functionality remains intact as those changes were unrelated to these authentication options.